### PR TITLE
if mobGriefing is false, Hecate no longer attack golems

### DIFF
--- a/src/main/java/am2/entities/EntityHecate.java
+++ b/src/main/java/am2/entities/EntityHecate.java
@@ -89,7 +89,9 @@ public class EntityHecate extends EntityZombie{
 		this.tasks.addTask(8, new EntityAIWatchClosest(this, EntityPlayer.class, 8.0F));
 		this.tasks.addTask(8, new EntityAILookIdle(this));
 		this.targetTasks.addTask(1, new EntityAIHurtByTarget(this, false));
-		this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntityGolem.class, 0, false));
+		if(this.worldObj.getGameRules().getGameRuleBooleanValue("mobGriefing")) { // if mobGriefing is allowed, Hecate will actively attack golems, including TC4 ones
+			this.targetTasks.addTask(2, new EntityAINearestAttackableTarget(this, EntityGolem.class, 0, false));
+		}
 		this.targetTasks.addTask(3, new EntityAINearestAttackableTarget(this, EntityPlayer.class, 0, true));
 		this.targetTasks.addTask(3, new EntityAINearestAttackableTarget(this, EntityVillager.class, 0, false));
 	}


### PR DESCRIPTION
Hecate are cool but also an annoyance if you are playing with TC4, since they attack golems. This change adds a condition that they only do so if mobGriefing is enabled.